### PR TITLE
Disable website report generation, require barcode upload

### DIFF
--- a/erp-valuation/templates/engineer_transaction_details.html
+++ b/erp-valuation/templates/engineer_transaction_details.html
@@ -127,13 +127,10 @@
   <div class="card mb-3">
     <div class="card-header bg-info text-white">📑 رفع تقرير</div>
     <div class="card-body">
-    <div class="mb-3">
-      <a href="{{ url_for('engineer_report_editor', tid=t.id) }}" class="btn btn-outline-primary">✍️ تحرير التقرير من القالب</a>
-    </div>
 <form action="{{ url_for('engineer_upload_report', tid=t.id) }}" method="POST" enctype="multipart/form-data">
   <div class="mb-3">
-    <label for="report_file" class="form-label">اختر ملف التقرير:</label>
-    <input type="file" class="form-control" name="report_file" required>
+    <label for="report_file" class="form-label">اختر ملف التقرير (PDF فقط):</label>
+    <input type="file" class="form-control" name="report_file" accept=".pdf" required>
   </div>
   <button type="submit" class="btn btn-success">⬆️ رفع التقرير</button>
 </form>

--- a/erp-valuation/templates/manager_dashboard.html
+++ b/erp-valuation/templates/manager_dashboard.html
@@ -33,7 +33,7 @@
         <li class="nav-item"><a class="nav-link" href="{{ url_for('banks_overview') }}">🏦 البنوك</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('branch_documents') }}">📁 مستندات الفروع</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('commissions_page') }}">💸 عمولة الموظفين</a></li>
-        <li class="nav-item"><a class="nav-link" href="{{ url_for('manage_report_templates') }}">🧩 قوالب التقارير</a></li>
+        
         <li class="nav-item">
             <a class="nav-link text-warning" href="/reports">📑 التقارير</a>
           </li>


### PR DESCRIPTION
Disable in-app report creation by removing UI links and restricting report uploads to PDF files.

---
<a href="https://cursor.com/background-agent?bcId=bc-c866569e-1399-420f-9a74-ed16a5fc193a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c866569e-1399-420f-9a74-ed16a5fc193a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

