### PR TITLE
Restrict invoice template uploads to admin

### DIFF
--- a/erp-valuation/app.py
+++ b/erp-valuation/app.py
@@ -1588,10 +1588,14 @@ def finance_paid():
 # ---------------- إدارة قوالب وورد (مالية) ----------------
 @app.route("/finance/templates", methods=["GET", "POST"])
 def finance_templates():
-    if session.get("role") != "finance":
+    if session.get("role") not in ["finance", "manager"]:
         return redirect(url_for("login"))
 
     if request.method == "POST":
+        # 🛡️ السماح للمدير فقط برفع/تحديث القوالب
+        if session.get("role") != "manager":
+            flash("🚫 مسموح للمدير فقط برفع القوالب", "danger")
+            return redirect(url_for("finance_templates"))
         doc_type = request.form.get("doc_type")  # invoice | quote
         file = request.files.get("file")
         # 🆕 تحديد الفرع المستهدف (اختياري)

--- a/erp-valuation/templates/finance_templates.html
+++ b/erp-valuation/templates/finance_templates.html
@@ -30,6 +30,7 @@
       <div class="card">
         <div class="card-body">
           <h5 class="mb-3">رفع قالب عرض سعر</h5>
+          {% if session.get('role') == 'manager' %}
           <form method="post" enctype="multipart/form-data">
             <input type="hidden" name="doc_type" value="quote">
             <div class="mb-2">
@@ -51,6 +52,12 @@
               <span class="ms-2 text-muted">الحالي: {{ templates.quote }}</span>
             {% endif %}
           </form>
+          {% else %}
+            {% if templates.quote %}
+              <div class="text-muted">القالب الحالي: {{ templates.quote }}</div>
+            {% endif %}
+            <div class="alert alert-warning mt-2 mb-0">رفع القوالب مسموح للمدير فقط</div>
+          {% endif %}
         </div>
       </div>
     </div>
@@ -58,6 +65,7 @@
       <div class="card">
         <div class="card-body">
           <h5 class="mb-3">رفع قالب فاتورة</h5>
+          {% if session.get('role') == 'manager' %}
           <form method="post" enctype="multipart/form-data">
             <input type="hidden" name="doc_type" value="invoice">
             <div class="mb-2">
@@ -79,6 +87,12 @@
               <span class="ms-2 text-muted">الحالي: {{ templates.invoice }}</span>
             {% endif %}
           </form>
+          {% else %}
+            {% if templates.invoice %}
+              <div class="text-muted">القالب الحالي: {{ templates.invoice }}</div>
+            {% endif %}
+            <div class="alert alert-warning mt-2 mb-0">رفع القوالب مسموح للمدير فقط</div>
+          {% endif %}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Restrict invoice and quote template uploads to managers only, and update the UI to hide upload forms from non-managers.

---
<a href="https://cursor.com/background-agent?bcId=bc-484b609c-4f9f-4768-b3be-b9505dc5db8a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-484b609c-4f9f-4768-b3be-b9505dc5db8a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

