### PR TITLE
Update invoice template with INV-CUST reference

### DIFF
--- a/erp-valuation/static/css/print-invoice.css
+++ b/erp-valuation/static/css/print-invoice.css
@@ -88,14 +88,14 @@ body {
 .info-box .label { color: #64748b; font-size: 12px; }
 .info-box .value { font-weight: 600; }
 
-table.items { width: 100%; border-collapse: collapse; }
+table.items { width: 100%; border-collapse: collapse; text-align: center; border: 1px solid #e5e7eb; border-radius: 10px; overflow: hidden; }
 table.items thead th {
-  text-align: right; background: linear-gradient(90deg, var(--brand-secondary), var(--brand-primary)); color: #ffffff; font-weight: 700; padding: 12px; border-bottom: 0; box-shadow: inset 0 -1px 0 rgba(2,6,23,0.08);
+  text-align: center; background: linear-gradient(90deg, var(--brand-secondary), var(--brand-primary)); color: #ffffff; font-weight: 700; padding: 12px; border-bottom: 0; box-shadow: inset 0 -1px 0 rgba(2,6,23,0.08);
 }
 table.items tbody td { padding: 10px 12px; border-bottom: 1px solid #f1f5f9; }
 table.items tbody tr:nth-child(even) td { background: rgba(14,165,233,0.06); }
-table.items tbody tr:hover td { background: rgba(109,40,217,0.06); }
-table.items tfoot td { padding: 10px 12px; }
+table.items tbody tr:hover td { background: rgba(109,40,217,0.08); }
+table.items tfoot td { padding: 10px 12px; background: rgba(14,165,233,0.06); }
 
 .totals {
   display: grid;

--- a/erp-valuation/templates/print_invoice.html
+++ b/erp-valuation/templates/print_invoice.html
@@ -23,7 +23,7 @@
           <div class="meta-grid mt-2">
             <div><span class="section-title">رقم الفاتورة</span><div class="fw-bold">INV-{{ transaction.id }}</div></div>
             <div><span class="section-title">التاريخ</span><div class="fw-bold">{{ date_str }}</div></div>
-            <div><span class="section-title">المرجع</span><div class="fw-bold">INV-{{ transaction.id }}</div></div>
+            <div><span class="section-title">المرجع</span><div class="fw-bold">INV-CUST</div></div>
             <div><span class="section-title">الموظف</span><div class="fw-bold">{{ transaction.employee or '-' }}</div></div>
           </div>
         </div>

--- a/erp-valuation/templates/print_invoice.html
+++ b/erp-valuation/templates/print_invoice.html
@@ -48,18 +48,18 @@
         <table class="items">
           <thead>
             <tr>
-              <th>الوصف</th>
-              <th style="width:120px">الكمية</th>
-              <th style="width:160px">سعر الوحدة</th>
               <th style="width:160px">الإجمالي</th>
+              <th style="width:160px">سعر الوحدة</th>
+              <th style="width:120px">الكمية</th>
+              <th>الوصف</th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <td>رسوم التثمين{% if transaction.status %} - {{ transaction.status }}{% endif %}</td>
+              <td>{{ amount | round(2) }}</td>
+              <td>{{ amount | round(2) }}</td>
               <td>1</td>
-              <td>{{ amount | round(2) }}</td>
-              <td>{{ amount | round(2) }}</td>
+              <td>رسوم التثمين{% if transaction.status %} - {{ transaction.status }}{% endif %}</td>
             </tr>
           </tbody>
           <tfoot>


### PR DESCRIPTION
Update invoice template to display "INV-CUST" in the reference field instead of the transaction number.

---
<a href="https://cursor.com/background-agent?bcId=bc-f06a6851-d181-4b3d-86e8-343270f4a9c9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f06a6851-d181-4b3d-86e8-343270f4a9c9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

