### PR TITLE
Fix javascript syntax error

### DIFF
--- a/erp-valuation/templates/finance.html
+++ b/erp-valuation/templates/finance.html
@@ -206,8 +206,8 @@
                   </select>
                 </div>
                 <div class="col-12 d-flex gap-2 flex-wrap">
-                  <a href="#" onclick="this.closest('form').action='{{ url_for('download_quote_doc', transaction_id=t.id) }}'; this.closest('form').submit(); return false;" class="btn btn-outline-primary btn-sm">عرض سعر</a>
-                  <a href="#" onclick="this.closest('form').action='{{ url_for('download_invoice_doc', transaction_id=t.id) }}'; this.closest('form').submit(); return false;" class="btn btn-outline-secondary btn-sm">فاتورة</a>
+                  <a href="{{ url_for('download_quote_doc', transaction_id=t.id) }}" onclick="this.closest('form').action=this.getAttribute('href'); this.closest('form').submit(); return false;" class="btn btn-outline-primary btn-sm">عرض سعر</a>
+                  <a href="{{ url_for('download_invoice_doc', transaction_id=t.id) }}" onclick="this.closest('form').action=this.getAttribute('href'); this.closest('form').submit(); return false;" class="btn btn-outline-secondary btn-sm">فاتورة</a>
                   <a href="{{ url_for('print_invoice_html', transaction_id=t.id) }}?auto=1" class="btn btn-sm btn-success">طباعة</a>
                 </div>
               </form>


### PR DESCRIPTION
Refactor inline `onclick` handlers to move dynamic URLs to `href` attributes, resolving JavaScript syntax errors caused by nested quotes.

---
<a href="https://cursor.com/background-agent?bcId=bc-a3ef9928-33fb-4749-bd2d-12a62125a88a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a3ef9928-33fb-4749-bd2d-12a62125a88a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

