### PR TITLE
Remove invoice timestamp for letterhead printing

### DIFF
--- a/erp-valuation/static/css/print-invoice.css
+++ b/erp-valuation/static/css/print-invoice.css
@@ -121,6 +121,11 @@ table.items tfoot td { padding: 10px 12px; background: rgba(14,165,233,0.06); }
 .btn:hover { filter: brightness(1.05) saturate(1.05); }
 .btn.secondary { background: linear-gradient(90deg, #475569, #334155); }
 
+@page {
+  size: auto;
+  margin: 0;
+}
+
 @media print {
   body { background: #ffffff; }
   .no-print { display: none !important; }

--- a/erp-valuation/templates/print_bank_invoice.html
+++ b/erp-valuation/templates/print_bank_invoice.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>🧾 طباعة فاتورة بنك</title>
+  <title>فاتورة بنك</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='css/bootstrap.min.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/print-invoice.css') }}">
 </head>
@@ -104,6 +104,11 @@
   </div>
   <script>
     (function(){
+      var originalTitle = document.title;
+      function beforePrint(){ document.title = ' '; }
+      function afterPrint(){ document.title = originalTitle; }
+      window.addEventListener('beforeprint', beforePrint);
+      window.addEventListener('afterprint', afterPrint);
       try {
         var usp = new URLSearchParams(window.location.search);
         if (usp.get('auto') === '1') { setTimeout(function(){ window.print(); }, 300); }

--- a/erp-valuation/templates/print_customer_invoice.html
+++ b/erp-valuation/templates/print_customer_invoice.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>🧾 طباعة فاتورة عميل</title>
+  <title>فاتورة عميل</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='css/bootstrap.min.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/print-invoice.css') }}">
 </head>
@@ -104,6 +104,11 @@
   </div>
   <script>
     (function(){
+      var originalTitle = document.title;
+      function beforePrint(){ document.title = ' '; }
+      function afterPrint(){ document.title = originalTitle; }
+      window.addEventListener('beforeprint', beforePrint);
+      window.addEventListener('afterprint', afterPrint);
       try {
         var usp = new URLSearchParams(window.location.search);
         if (usp.get('auto') === '1') { setTimeout(function(){ window.print(); }, 300); }

--- a/erp-valuation/templates/print_invoice.html
+++ b/erp-valuation/templates/print_invoice.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>🧾 طباعة فاتورة</title>
+  <title>فاتورة</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='css/bootstrap.min.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/print-invoice.css') }}">
 </head>
@@ -103,8 +103,12 @@
     </div>
   </div>
   <script>
-    // Auto-open print dialog if requested via query string
     (function(){
+      var originalTitle = document.title;
+      function beforePrint(){ document.title = ' '; }
+      function afterPrint(){ document.title = originalTitle; }
+      window.addEventListener('beforeprint', beforePrint);
+      window.addEventListener('afterprint', afterPrint);
       try {
         var usp = new URLSearchParams(window.location.search);
         if (usp.get('auto') === '1') { setTimeout(function(){ window.print(); }, 300); }


### PR DESCRIPTION
Remove browser print headers and margins from invoice printouts to enable clean printing on letterhead.

---
<a href="https://cursor.com/background-agent?bcId=bc-240f07df-f36c-466d-bcec-ee1ccaf61b4b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-240f07df-f36c-466d-bcec-ee1ccaf61b4b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

