### PR TITLE
Fix manager not seeing bank documents

### DIFF
--- a/erp-valuation/templates/manager_dashboard.html
+++ b/erp-valuation/templates/manager_dashboard.html
@@ -86,6 +86,20 @@
               <span><strong>💵 الرسوم:</strong> {{ "{:,.0f}".format(t.fee) }} ريال</span>
               <span class="text-muted">الإجراءات تتم بواسطة المهندس والمالية</span>
             </div>
+            {% if t.bank_sent_files %}
+            <hr>
+            <div class="mt-2">
+              <p class="mb-2"><strong>📎 المستندات المرسلة للبنك:</strong></p>
+              <ul class="mb-0">
+                {% for fname in (t.bank_sent_files or '').split(',') %}
+                  {% set f = (fname or '').strip() %}
+                  {% if f %}
+                  <li><a href="{{ url_for('uploaded_file', filename=f) }}" target="_blank">{{ f }}</a></li>
+                  {% endif %}
+                {% endfor %}
+              </ul>
+            </div>
+            {% endif %}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Add bank-sent documents to the manager dashboard to ensure visibility for managers.

---
<a href="https://cursor.com/background-agent?bcId=bc-fd82c5e0-bedc-491e-849c-8784a5515f89">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fd82c5e0-bedc-491e-849c-8784a5515f89">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

