### PR TITLE
Fix bank documents not appearing for admin

### DIFF
--- a/erp-valuation/templates/bank_detail.html
+++ b/erp-valuation/templates/bank_detail.html
@@ -77,12 +77,15 @@
 
   <div class="card shadow-sm">
     <div class="card-header bg-dark text-white d-flex">
+      {% set has_invoices = invoices and (invoices|length) > 0 %}
+      {% set has_docs = documents and (documents|length) > 0 %}
+      {% set active_tab = request.args.get('tab') or ('docs' if (has_docs and not has_invoices) else 'invoices') %}
       <ul class="nav nav-tabs card-header-tabs" id="bankTabs" role="tablist">
         <li class="nav-item" role="presentation">
-          <button class="nav-link active" id="invoices-tab" data-bs-toggle="tab" data-bs-target="#invoices" type="button" role="tab">📄 الفواتير المرسلة للبنك</button>
+          <button class="nav-link {{ 'active' if active_tab == 'invoices' else '' }}" id="invoices-tab" data-bs-toggle="tab" data-bs-target="#invoices" type="button" role="tab" aria-selected="{{ 'true' if active_tab == 'invoices' else 'false' }}">📄 الفواتير المرسلة للبنك</button>
         </li>
         <li class="nav-item" role="presentation">
-          <button class="nav-link" id="docs-tab" data-bs-toggle="tab" data-bs-target="#docs" type="button" role="tab">📎 المستندات المرسلة</button>
+          <button class="nav-link {{ 'active' if active_tab == 'docs' else '' }}" id="docs-tab" data-bs-toggle="tab" data-bs-target="#docs" type="button" role="tab" aria-selected="{{ 'true' if active_tab == 'docs' else 'false' }}">📎 المستندات المرسلة</button>
         </li>
         <li class="nav-item" role="presentation">
           <button class="nav-link" id="stages-tab" data-bs-toggle="tab" data-bs-target="#stages" type="button" role="tab">✅ مراحل فواتير البنك</button>
@@ -91,7 +94,7 @@
     </div>
     <div class="card-body">
       <div class="tab-content">
-        <div class="tab-pane fade show active" id="invoices" role="tabpanel">
+        <div class="tab-pane fade {{ 'show active' if active_tab == 'invoices' else '' }}" id="invoices" role="tabpanel">
           <div class="table-responsive">
             <table class="table table-bordered table-striped">
               <thead class="table-dark">
@@ -122,7 +125,7 @@
           </div>
         </div>
 
-        <div class="tab-pane fade" id="docs" role="tabpanel">
+        <div class="tab-pane fade {{ 'show active' if active_tab == 'docs' else '' }}" id="docs" role="tabpanel">
           <div class="table-responsive">
             <table class="table table-bordered table-striped">
               <thead class="table-dark">


### PR DESCRIPTION
Set the 'Documents' tab as default on the bank detail page when no invoices are present, and allow URL-based tab selection, to ensure sent documents are visible.

---
<a href="https://cursor.com/background-agent?bcId=bc-03df53f6-9f4c-4e6d-8f5f-0fa252b114ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-03df53f6-9f4c-4e6d-8f5f-0fa252b114ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

