### PR TITLE
Organize finance page into tabs

### DIFF
--- a/erp-valuation/templates/finance.html
+++ b/erp-valuation/templates/finance.html
@@ -19,6 +19,7 @@
       </ul>
     </div>
   </div>
+
 </nav>
 {% endblock %}
 
@@ -26,106 +27,271 @@
 <div class="container py-4">
   <h2 class="mb-4" data-aos="fade-up">💰 لوحة التحكم المالية</h2>
 
-  <div class="row mb-4" data-aos="fade-up">
-    <div class="col-md-6" data-aos="zoom-in">
-      <div class="card shadow-sm">
-        <div class="card-body">
-          <h5 class="mb-3">📄 إنشاء فاتورة بنك</h5>
-          <form method="POST" action="{{ url_for('finance_create_bank_invoice') }}" class="row g-2">
-            <div class="col-md-6">
-              <label class="form-label">البنك</label>
-              <select name="bank_id" class="form-select" required>
-                <option value="">اختر البنك</option>
-                {% for b in banks %}
-                  <option value="{{ b.id }}">{{ b.name }}</option>
-                {% endfor %}
-              </select>
+  <!-- Tabs header -->
+  <ul class="nav nav-tabs mb-3" id="financeTabs" role="tablist">
+    <li class="nav-item" role="presentation">
+      <button class="nav-link active" id="bank-invoices-tab" data-bs-toggle="tab" data-bs-target="#bank-invoices" type="button" role="tab" aria-controls="bank-invoices" aria-selected="true">🏦 فواتير البنوك</button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="customer-quotes-tab" data-bs-toggle="tab" data-bs-target="#customer-quotes" type="button" role="tab" aria-controls="customer-quotes" aria-selected="false">🧾 عروض الأسعار</button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="customer-invoices-tab" data-bs-toggle="tab" data-bs-target="#customer-invoices" type="button" role="tab" aria-controls="customer-invoices" aria-selected="false">🧮 فواتير العملاء</button>
+    </li>
+  </ul>
+
+  <div class="tab-content mb-4" id="financeTabsContent">
+    <!-- Bank Invoices Tab -->
+    <div class="tab-pane fade show active" id="bank-invoices" role="tabpanel" aria-labelledby="bank-invoices-tab" tabindex="0">
+      <div class="row mb-4" data-aos="fade-up">
+        <div class="col-md-6" data-aos="zoom-in">
+          <div class="card shadow-sm">
+            <div class="card-body">
+              <h5 class="mb-3">📄 إنشاء فاتورة بنك</h5>
+              <form method="POST" action="{{ url_for('finance_create_bank_invoice') }}" class="row g-2">
+                <div class="col-md-6">
+                  <label class="form-label">البنك</label>
+                  <select name="bank_id" class="form-select" required>
+                    <option value="">اختر البنك</option>
+                    {% for b in banks %}
+                      <option value="{{ b.id }}">{{ b.name }}</option>
+                    {% endfor %}
+                  </select>
+                </div>
+                <div class="col-md-6">
+                  <label class="form-label">المبلغ</label>
+                  <input type="number" step="0.01" name="amount" class="form-control" required>
+                </div>
+                <div class="col-md-6">
+                  <label class="form-label">رقم معاملة (اختياري)</label>
+                  <input type="number" name="transaction_id" class="form-control" placeholder="إن وجد">
+                </div>
+                <div class="col-md-6">
+                  <label class="form-label">ملاحظة</label>
+                  <input type="text" name="note" class="form-control" placeholder="ملاحظة">
+                </div>
+                <div class="col-12 d-flex justify-content-end">
+                  <button class="btn btn-success">إصدار فاتورة</button>
+                </div>
+              </form>
             </div>
-            <div class="col-md-6">
-              <label class="form-label">المبلغ</label>
-              <input type="number" step="0.01" name="amount" class="form-control" required>
+          </div>
+        </div>
+      </div>
+
+      <div class="row mb-4" data-aos="fade-up">
+        <div class="col-md-12">
+          <div class="card shadow-sm">
+            <div class="card-body">
+              <h5 class="mb-3">📄 آخر فواتير البنوك</h5>
+              <div class="table-responsive">
+                <table class="table table-bordered table-striped">
+                  <thead class="table-dark">
+                    <tr>
+                      <th>#</th>
+                      <th>البنك</th>
+                      <th>المبلغ</th>
+                      <th>إصدار</th>
+                      <th>تسليم</th>
+                      <th>استلام</th>
+                      <th>الحالة</th>
+                      <th>إجراءات</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for inv in recent_bank_invoices %}
+                    <tr>
+                      <td>{{ inv.id }}</td>
+                      <td>{{ inv.bank_id }}</td>
+                      <td>{{ inv.amount }}</td>
+                      <td>{{ inv.issued_at.strftime('%Y-%m-%d') if inv.issued_at else '-' }}</td>
+                      <td>{{ inv.delivered_at.strftime('%Y-%m-%d') if inv.delivered_at else '-' }}</td>
+                      <td>{{ inv.received_at.strftime('%Y-%m-%d') if inv.received_at else '-' }}</td>
+                      <td>
+                        {% if inv.received_at %}تم استلام المبلغ{% elif inv.delivered_at %}تم التسليم{% elif inv.issued_at %}تم الإصدار{% else %}-{% endif %}
+                      </td>
+                      <td class="text-nowrap">
+                        <div class="d-flex gap-2 flex-wrap">
+                          <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('download_bank_invoice_doc', invoice_id=inv.id) }}">تنزيل</a>
+                          {% if not inv.delivered_at %}
+                          <form method="post" action="{{ url_for('finance_update_bank_invoice_status', invoice_id=inv.id) }}">
+                            <input type="hidden" name="action" value="deliver">
+                            <button class="btn btn-sm btn-warning">تسليم</button>
+                          </form>
+                          {% endif %}
+                          {% if inv.delivered_at and not inv.received_at %}
+                          <form method="post" action="{{ url_for('finance_update_bank_invoice_status', invoice_id=inv.id) }}">
+                            <input type="hidden" name="action" value="receive">
+                            <button class="btn btn-sm btn-success">استلام</button>
+                          </form>
+                          {% endif %}
+                        </div>
+                      </td>
+                    </tr>
+                    {% else %}
+                    <tr><td colspan="6" class="text-center">لا توجد فواتير بعد</td></tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
             </div>
-            <div class="col-md-6">
-              <label class="form-label">رقم معاملة (اختياري)</label>
-              <input type="number" name="transaction_id" class="form-control" placeholder="إن وجد">
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Customer Quotes Tab -->
+    <div class="tab-pane fade" id="customer-quotes" role="tabpanel" aria-labelledby="customer-quotes-tab" tabindex="0">
+      <div class="row mb-4" data-aos="fade-up">
+        <div class="col-md-6" data-aos="zoom-in">
+          <div class="card shadow-sm">
+            <div class="card-body">
+              <h5 class="mb-3">🧾 إنشاء عرض سعر للعميل</h5>
+              <form method="POST" action="{{ url_for('finance_create_customer_quote') }}" class="row g-2">
+                <div class="col-md-6">
+                  <label class="form-label">اسم العميل</label>
+                  <input type="text" name="customer_name" class="form-control" required>
+                </div>
+                <div class="col-md-6">
+                  <label class="form-label">المبلغ</label>
+                  <input type="number" step="0.01" name="amount" class="form-control" required>
+                </div>
+                <div class="col-md-6">
+                  <label class="form-label">صالح حتى (اختياري)</label>
+                  <input type="date" name="valid_until" class="form-control">
+                </div>
+                <div class="col-md-6">
+                  <label class="form-label">رقم معاملة (اختياري)</label>
+                  <input type="number" name="transaction_id" class="form-control" placeholder="إن وجد">
+                </div>
+                <div class="col-12">
+                  <label class="form-label">ملاحظة</label>
+                  <input type="text" name="note" class="form-control" placeholder="ملاحظة">
+                </div>
+                <div class="col-12 d-flex justify-content-end">
+                  <button class="btn btn-primary">إنشاء</button>
+                </div>
+              </form>
             </div>
-            <div class="col-md-6">
-              <label class="form-label">ملاحظة</label>
-              <input type="text" name="note" class="form-control" placeholder="ملاحظة">
+          </div>
+        </div>
+      </div>
+
+      <div class="row mb-4" data-aos="fade-up">
+        <div class="col-md-12">
+          <div class="card shadow-sm">
+            <div class="card-body">
+              <h5 class="mb-3">🧾 آخر عروض أسعار العملاء</h5>
+              <div class="table-responsive">
+                <table class="table table-bordered table-striped">
+                  <thead class="table-dark">
+                    <tr>
+                      <th>#</th>
+                      <th>العميل</th>
+                      <th>المبلغ</th>
+                      <th>صالح حتى</th>
+                      <th>ملاحظة</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for q in recent_customer_quotes %}
+                    <tr>
+                      <td>{{ q.id }}</td>
+                      <td>{{ q.customer_name }}</td>
+                      <td>{{ q.amount }}</td>
+                      <td>{{ q.valid_until.strftime('%Y-%m-%d') if q.valid_until else '-' }}</td>
+                      <td class="d-flex gap-2">
+                        <span>{{ q.note or '-' }}</span>
+                        <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('download_customer_quote_doc', quote_id=q.id) }}">تنزيل</a>
+                      </td>
+                    </tr>
+                    {% else %}
+                    <tr><td colspan="5" class="text-center">لا توجد عروض عملاء بعد</td></tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
             </div>
-            <div class="col-12 d-flex justify-content-end">
-              <button class="btn btn-success">إصدار فاتورة</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Customer Invoices Tab -->
+    <div class="tab-pane fade" id="customer-invoices" role="tabpanel" aria-labelledby="customer-invoices-tab" tabindex="0">
+      <div class="row mb-4" data-aos="fade-up">
+        <div class="col-md-6" data-aos="zoom-in" data-aos-delay="80">
+          <div class="card shadow-sm">
+            <div class="card-body">
+              <h5 class="mb-3">🧮 إنشاء فاتورة للعميل</h5>
+              <form method="POST" action="{{ url_for('finance_create_customer_invoice') }}" class="row g-2">
+                <div class="col-md-6">
+                  <label class="form-label">اسم العميل</label>
+                  <input type="text" name="customer_name" class="form-control" required>
+                </div>
+                <div class="col-md-6">
+                  <label class="form-label">المبلغ</label>
+                  <input type="number" step="0.01" name="amount" class="form-control" required>
+                </div>
+                <div class="col-md-6">
+                  <label class="form-label">رقم معاملة (اختياري)</label>
+                  <input type="number" name="transaction_id" class="form-control" placeholder="إن وجد">
+                </div>
+                <div class="col-md-6">
+                  <label class="form-label">ملاحظة</label>
+                  <input type="text" name="note" class="form-control" placeholder="ملاحظة">
+                </div>
+                <div class="col-12 d-flex justify-content-end">
+                  <button class="btn btn-success">إصدار فاتورة</button>
+                </div>
+              </form>
             </div>
-          </form>
+          </div>
+        </div>
+      </div>
+
+      <div class="row mb-4" data-aos="fade-up">
+        <div class="col-md-12">
+          <div class="card shadow-sm">
+            <div class="card-body">
+              <h5 class="mb-3">🧮 آخر فواتير العملاء</h5>
+              <div class="table-responsive">
+                <table class="table table-bordered table-striped">
+                  <thead class="table-dark">
+                    <tr>
+                      <th>#</th>
+                      <th>العميل</th>
+                      <th>المبلغ</th>
+                      <th>تاريخ الإصدار</th>
+                      <th>ملاحظة</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for inv in recent_customer_invoices %}
+                    <tr>
+                      <td>{{ inv.id }}</td>
+                      <td>{{ inv.customer_name }}</td>
+                      <td>{{ inv.amount }}</td>
+                      <td>{{ inv.issued_at.strftime('%Y-%m-%d') if inv.issued_at else '-' }}</td>
+                      <td class="d-flex gap-2">
+                        <span>{{ inv.note or '-' }}</span>
+                        <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('download_customer_invoice_doc', invoice_id=inv.id) }}">تنزيل</a>
+                      </td>
+                    </tr>
+                    {% else %}
+                    <tr><td colspan="5" class="text-center">لا توجد فواتير عملاء بعد</td></tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
   </div>
 
-  <div class="row mb-4" data-aos="fade-up">
-    <div class="col-md-6" data-aos="zoom-in">
-      <div class="card shadow-sm">
-        <div class="card-body">
-          <h5 class="mb-3">🧾 إنشاء عرض سعر للعميل</h5>
-          <form method="POST" action="{{ url_for('finance_create_customer_quote') }}" class="row g-2">
-            <div class="col-md-6">
-              <label class="form-label">اسم العميل</label>
-              <input type="text" name="customer_name" class="form-control" required>
-            </div>
-            <div class="col-md-6">
-              <label class="form-label">المبلغ</label>
-              <input type="number" step="0.01" name="amount" class="form-control" required>
-            </div>
-            <div class="col-md-6">
-              <label class="form-label">صالح حتى (اختياري)</label>
-              <input type="date" name="valid_until" class="form-control">
-            </div>
-            <div class="col-md-6">
-              <label class="form-label">رقم معاملة (اختياري)</label>
-              <input type="number" name="transaction_id" class="form-control" placeholder="إن وجد">
-            </div>
-            <div class="col-12">
-              <label class="form-label">ملاحظة</label>
-              <input type="text" name="note" class="form-control" placeholder="ملاحظة">
-            </div>
-            <div class="col-12 d-flex justify-content-end">
-              <button class="btn btn-primary">إنشاء</button>
-            </div>
-          </form>
-        </div>
-      </div>
-    </div>
-
-    <div class="col-md-6" data-aos="zoom-in" data-aos-delay="80">
-      <div class="card shadow-sm">
-        <div class="card-body">
-          <h5 class="mb-3">🧮 إنشاء فاتورة للعميل</h5>
-          <form method="POST" action="{{ url_for('finance_create_customer_invoice') }}" class="row g-2">
-            <div class="col-md-6">
-              <label class="form-label">اسم العميل</label>
-              <input type="text" name="customer_name" class="form-control" required>
-            </div>
-            <div class="col-md-6">
-              <label class="form-label">المبلغ</label>
-              <input type="number" step="0.01" name="amount" class="form-control" required>
-            </div>
-            <div class="col-md-6">
-              <label class="form-label">رقم معاملة (اختياري)</label>
-              <input type="number" name="transaction_id" class="form-control" placeholder="إن وجد">
-            </div>
-            <div class="col-md-6">
-              <label class="form-label">ملاحظة</label>
-              <input type="text" name="note" class="form-control" placeholder="ملاحظة">
-            </div>
-            <div class="col-12 d-flex justify-content-end">
-              <button class="btn btn-success">إصدار فاتورة</button>
-            </div>
-          </form>
-        </div>
-      </div>
-    </div>
-  </div>
-
+  <!-- KPIs -->
   <div class="row mb-4" data-aos="fade-up">
     <div class="col-md-4" data-aos="zoom-in">
       <div class="card shadow-sm text-center">
@@ -153,6 +319,7 @@
     </div>
   </div>
 
+  <!-- Unpaid transactions table remains as is -->
   <div class="card shadow-sm mb-4" data-aos="fade-up">
     <div class="card-body">
       <h5 class="mb-3">❌ المعاملات غير المدفوعة</h5>
@@ -219,141 +386,7 @@
     </div>
   </div>
 
-  <div class="row mb-4" data-aos="fade-up">
-    <div class="col-md-12">
-      <div class="card shadow-sm">
-        <div class="card-body">
-          <h5 class="mb-3">📄 آخر فواتير البنوك</h5>
-          <div class="table-responsive">
-            <table class="table table-bordered table-striped">
-              <thead class="table-dark">
-                <tr>
-                  <th>#</th>
-                  <th>البنك</th>
-                  <th>المبلغ</th>
-                  <th>إصدار</th>
-                  <th>تسليم</th>
-                  <th>استلام</th>
-                  <th>الحالة</th>
-                  <th>إجراءات</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for inv in recent_bank_invoices %}
-                <tr>
-                  <td>{{ inv.id }}</td>
-                  <td>{{ inv.bank_id }}</td>
-                  <td>{{ inv.amount }}</td>
-                  <td>{{ inv.issued_at.strftime('%Y-%m-%d') if inv.issued_at else '-' }}</td>
-                  <td>{{ inv.delivered_at.strftime('%Y-%m-%d') if inv.delivered_at else '-' }}</td>
-                  <td>{{ inv.received_at.strftime('%Y-%m-%d') if inv.received_at else '-' }}</td>
-                  <td>
-                    {% if inv.received_at %}تم استلام المبلغ{% elif inv.delivered_at %}تم التسليم{% elif inv.issued_at %}تم الإصدار{% else %}-{% endif %}
-                  </td>
-                  <td class="text-nowrap">
-                    <div class="d-flex gap-2 flex-wrap">
-                      <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('download_bank_invoice_doc', invoice_id=inv.id) }}">تنزيل</a>
-                      {% if not inv.delivered_at %}
-                      <form method="post" action="{{ url_for('finance_update_bank_invoice_status', invoice_id=inv.id) }}">
-                        <input type="hidden" name="action" value="deliver">
-                        <button class="btn btn-sm btn-warning">تسليم</button>
-                      </form>
-                      {% endif %}
-                      {% if inv.delivered_at and not inv.received_at %}
-                      <form method="post" action="{{ url_for('finance_update_bank_invoice_status', invoice_id=inv.id) }}">
-                        <input type="hidden" name="action" value="receive">
-                        <button class="btn btn-sm btn-success">استلام</button>
-                      </form>
-                      {% endif %}
-                    </div>
-                  </td>
-                </tr>
-                {% else %}
-                <tr><td colspan="6" class="text-center">لا توجد فواتير بعد</td></tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <div class="row mb-4" data-aos="fade-up">
-    <div class="col-md-6">
-      <div class="card shadow-sm">
-        <div class="card-body">
-          <h5 class="mb-3">🧾 آخر عروض أسعار العملاء</h5>
-          <div class="table-responsive">
-            <table class="table table-bordered table-striped">
-              <thead class="table-dark">
-                <tr>
-                  <th>#</th>
-                  <th>العميل</th>
-                  <th>المبلغ</th>
-                  <th>صالح حتى</th>
-                  <th>ملاحظة</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for q in recent_customer_quotes %}
-                <tr>
-                  <td>{{ q.id }}</td>
-                  <td>{{ q.customer_name }}</td>
-                  <td>{{ q.amount }}</td>
-                  <td>{{ q.valid_until.strftime('%Y-%m-%d') if q.valid_until else '-' }}</td>
-                  <td class="d-flex gap-2">
-                    <span>{{ q.note or '-' }}</span>
-                    <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('download_customer_quote_doc', quote_id=q.id) }}">تنزيل</a>
-                  </td>
-                </tr>
-                {% else %}
-                <tr><td colspan="5" class="text-center">لا توجد عروض عملاء بعد</td></tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="col-md-6">
-      <div class="card shadow-sm">
-        <div class="card-body">
-          <h5 class="mb-3">🧮 آخر فواتير العملاء</h5>
-          <div class="table-responsive">
-            <table class="table table-bordered table-striped">
-              <thead class="table-dark">
-                <tr>
-                  <th>#</th>
-                  <th>العميل</th>
-                  <th>المبلغ</th>
-                  <th>تاريخ الإصدار</th>
-                  <th>ملاحظة</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for inv in recent_customer_invoices %}
-                <tr>
-                  <td>{{ inv.id }}</td>
-                  <td>{{ inv.customer_name }}</td>
-                  <td>{{ inv.amount }}</td>
-                  <td>{{ inv.issued_at.strftime('%Y-%m-%d') if inv.issued_at else '-' }}</td>
-                  <td class="d-flex gap-2">
-                    <span>{{ inv.note or '-' }}</span>
-                    <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('download_customer_invoice_doc', invoice_id=inv.id) }}">تنزيل</a>
-                  </td>
-                </tr>
-                {% else %}
-                <tr><td colspan="5" class="text-center">لا توجد فواتير عملاء بعد</td></tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-
+  <!-- Add expense -->
   <div class="card shadow-sm" data-aos="fade-up">
     <div class="card-body">
       <h5 class="mb-3">➕ إضافة مصروف جديد</h5>


### PR DESCRIPTION
Organize the finance page by adding a tabbed layout for bank invoices, customer quotes, and customer invoices.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7591a44-a7b7-48c3-8a55-18bc3301ce72">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c7591a44-a7b7-48c3-8a55-18bc3301ce72">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

