### PR TITLE
Fix receipt URL not found error

### DIFF
--- a/erp-valuation/templates/engineer_transaction_details.html
+++ b/erp-valuation/templates/engineer_transaction_details.html
@@ -114,7 +114,7 @@
       {% if t.files %}
         <ul>
           {% for f in t.files.split(",") %}
-            <li><a href="{{ url_for('static', filename='uploads/' ~ f) }}" target="_blank">{{ f }}</a></li>
+            <li><a href="{{ url_for('uploaded_file', filename=f) }}" target="_blank">{{ f }}</a></li>
           {% endfor %}
         </ul>
       {% else %}

--- a/erp-valuation/templates/finance_paid.html
+++ b/erp-valuation/templates/finance_paid.html
@@ -55,7 +55,7 @@
               <td>{{ p.date_received.strftime('%Y-%m-%d') if p.date_received else '-' }}</td>
               <td>
                 {% if p.receipt_file %}
-                  <a href="{{ url_for('static', filename='uploads/' ~ p.receipt_file) }}" target="_blank">📎 عرض</a>
+                  <a href="{{ url_for('uploaded_file', filename=p.receipt_file) }}" target="_blank">📎 عرض</a>
                 {% else %}
                   -
                 {% endif %}


### PR DESCRIPTION
Fix broken receipt and file links by using the correct `uploaded_file` route instead of `static`.

The previous implementation used `url_for('static', filename='uploads/' ~ f)` which resulted in a "The requested URL was not found on the server" error when trying to access the files, as the server expects uploaded files via the `uploaded_file` endpoint.

---
<a href="https://cursor.com/background-agent?bcId=bc-5bd510b9-b328-4ff4-a4e5-190fbf18065c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5bd510b9-b328-4ff4-a4e5-190fbf18065c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

