### PR TITLE
Fix report qr code stamping error

### DIFF
--- a/erp-valuation/templates/engineer.html
+++ b/erp-valuation/templates/engineer.html
@@ -76,7 +76,7 @@
                     <a href="{{ url_for('engineer_take', tid=t.id) }}" class="btn btn-sm btn-primary">استلام</a>
                   {% elif t.assigned_to == engineer.id and t.status == "قيد المعاينة" %}
                     <form method="POST" action="{{ url_for('engineer_upload_report', tid=t.id) }}" enctype="multipart/form-data" class="d-flex align-items-center gap-2">
-                      <input type="file" name="report_file" class="form-control form-control-sm" accept=".pdf,.doc,.docx" required>
+                      <input type="file" name="report_file" class="form-control form-control-sm" accept=".pdf" required>
                       <button type="submit" class="btn btn-sm btn-success">📤 رفع</button>
                     </form>
                   {% endif %}

--- a/erp-valuation/templates/engineer_report.html
+++ b/erp-valuation/templates/engineer_report.html
@@ -42,8 +42,8 @@
       </div>
 
       <div class="mb-3">
-        <label class="form-label">ملف التقرير (PDF)</label>
-        <input type="file" name="report_file" class="form-control">
+        <label class="form-label">ملف التقرير (PDF فقط)</label>
+        <input type="file" name="report_file" class="form-control" accept=".pdf">
       </div>
 
       <button type="submit" class="btn btn-success">💾 حفظ التقرير</button>


### PR DESCRIPTION
Fix QR code stamping on reports by enforcing PDF-only uploads, improving stamp placement, and adding error logging for stamping failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-d1068695-9fd4-4017-b24a-ac9162c6e75a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d1068695-9fd4-4017-b24a-ac9162c6e75a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

