### PR TITLE
Fix missing endpoint for public report url

### DIFF
--- a/erp-valuation/app.py
+++ b/erp-valuation/app.py
@@ -3078,7 +3078,7 @@ def uploaded_file(filename):
     return send_from_directory(app.config["UPLOAD_FOLDER"], filename)
 
 # ---------------- رابط عام لمشاركة التقرير عبر رمز التحقق ----------------
-@app.route("/r/<token>")
+@app.route("/r/<token>", endpoint="public_report")
 def public_report(token):
     tx = Transaction.query.filter_by(verification_token=token).first()
     if not tx or not tx.report_file:


### PR DESCRIPTION
Add explicit endpoint name to `public_report` route to resolve `BuildError` when building URLs.

---
<a href="https://cursor.com/background-agent?bcId=bc-ff96e7cf-6099-4744-b28b-1f648e4718de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ff96e7cf-6099-4744-b28b-1f648e4718de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

