### PR TITLE
Fix javascript syntax error

### DIFF
--- a/erp-valuation/templates/engineer_transaction_details.html
+++ b/erp-valuation/templates/engineer_transaction_details.html
@@ -144,7 +144,7 @@
       🔗 رابط عام للتقرير:
       <a href="{{ url_for('public_report', token=t.verification_token, _external=True) }}" target="_blank">{{ url_for('public_report', token=t.verification_token, _external=True) }}</a>
     </div>
-    <button class="btn btn-sm btn-outline-primary" onclick="navigator.clipboard.writeText('{{ url_for('public_report', token=t.verification_token, _external=True) }}')">نسخ</button>
+    <button class="btn btn-sm btn-outline-primary" onclick="navigator.clipboard.writeText('{{ url_for("public_report", token=t.verification_token, _external=True) }}')">نسخ</button>
   </div>
   {% endif %}
 


### PR DESCRIPTION
Fix JavaScript syntax error in `onclick` attribute by changing inner Jinja quotes to double quotes.

---
<a href="https://cursor.com/background-agent?bcId=bc-e2c84146-96d7-4969-89d5-018b2da73141">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e2c84146-96d7-4969-89d5-018b2da73141">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

