### PR TITLE
Fix javascript syntax errors in template

### DIFF
--- a/erp-valuation/templates/engineer_transaction_details.html
+++ b/erp-valuation/templates/engineer_transaction_details.html
@@ -144,7 +144,7 @@
       🔗 رابط عام للتقرير:
       <a href="{{ url_for('public_report', token=t.verification_token, _external=True) }}" target="_blank">{{ url_for('public_report', token=t.verification_token, _external=True) }}</a>
     </div>
-    <button class="btn btn-sm btn-outline-primary" onclick='navigator.clipboard.writeText("{{ url_for("public_report", token=t.verification_token, _external=True) }}")'>نسخ</button>
+    <button class="btn btn-sm btn-outline-primary" onclick="navigator.clipboard.writeText({{ url_for('public_report', token=t.verification_token, _external=True) | tojson }})">نسخ</button>
   </div>
   {% endif %}
 


### PR DESCRIPTION
Fix JavaScript syntax error in `onclick` handler by safely embedding URL with Jinja's `tojson` filter.

---
<a href="https://cursor.com/background-agent?bcId=bc-db7c000b-957b-4307-b7fa-d40721084390">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-db7c000b-957b-4307-b7fa-d40721084390">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

