### PR TITLE
Fix javascript syntax errors in html

### DIFF
--- a/erp-valuation/templates/engineer_transaction_details.html
+++ b/erp-valuation/templates/engineer_transaction_details.html
@@ -144,12 +144,32 @@
       🔗 رابط عام للتقرير:
       <a href="{{ url_for('public_report', token=t.verification_token, _external=True) }}" target="_blank">{{ url_for('public_report', token=t.verification_token, _external=True) }}</a>
     </div>
-    <button class="btn btn-sm btn-outline-primary" onclick="navigator.clipboard.writeText({{ url_for('public_report', token=t.verification_token, _external=True) | tojson }})">نسخ</button>
+    <button class="btn btn-sm btn-outline-primary" id="copyPublicReportLink" data-clipboard-text="{{ url_for('public_report', token=t.verification_token, _external=True) }}">نسخ</button>
   </div>
   {% endif %}
 
   <a href="{{ url_for('engineer_dashboard') }}" class="btn btn-secondary">🔙 رجوع</a>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    var copyButton = document.getElementById('copyPublicReportLink');
+    if (copyButton) {
+      copyButton.addEventListener('click', function () {
+        var textToCopy = copyButton.getAttribute('data-clipboard-text');
+        if (!textToCopy) return;
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(textToCopy);
+        } else {
+          var tempInput = document.createElement('input');
+          tempInput.value = textToCopy;
+          document.body.appendChild(tempInput);
+          tempInput.select();
+          try { document.execCommand('copy'); } finally { document.body.removeChild(tempInput); }
+        }
+      });
+    }
+  });
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
Refactor clipboard copy functionality to fix JavaScript syntax errors caused by Jinja rendering in inline `onclick`.

The JavaScript parser was misinterpreting the Jinja template output within the `onclick` attribute, leading to syntax errors. By moving the URL into a `data-clipboard-text` attribute and handling the copy logic in a separate script block, we ensure proper JavaScript parsing and provide a more maintainable solution.

---
<a href="https://cursor.com/background-agent?bcId=bc-d77ae085-2189-411b-995b-71021c65481f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d77ae085-2189-411b-995b-71021c65481f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

