### PR TITLE
Troubleshoot employee sale transaction entry

### DIFF
--- a/erp-valuation/app.py
+++ b/erp-valuation/app.py
@@ -1279,7 +1279,7 @@ def engineer_take(tid):
     t.status = "قيد المعاينة"
 
     # 🆕 تخصيص رسالة حسب نوع المعاملة
-    if t.transaction_type == "سيارة":
+    if t.transaction_type == "vehicle":
         flash("🚗 تم استلام معاملة السيارة", "success")
     else:
         flash("🏠 تم استلام معاملة العقار", "success")

--- a/erp-valuation/templates/employee.html
+++ b/erp-valuation/templates/employee.html
@@ -381,6 +381,17 @@
     if (real) real.style.display = (type === "real_estate") ? "block" : "none";
     if (veh)  veh.style.display  = (type === "vehicle")     ? "block" : "none";
     if (box)  box.style.display  = (type === "real_estate") ? "block" : "none";
+
+    // تعطيل مدخلات القسم المخفي لتجاوز تحقق required في المتصفح
+    function setSectionDisabled(sectionEl, disabled) {
+      if (!sectionEl) return;
+      sectionEl.querySelectorAll("input, select, textarea").forEach(el => {
+        el.disabled = disabled;
+      });
+    }
+
+    setSectionDisabled(real, type !== "real_estate");
+    setSectionDisabled(veh,  type !== "vehicle");
   }
 
   // تغيّر النوع


### PR DESCRIPTION
Disable hidden form fields to fix silent submission failure for 'vehicle' transactions and correct the engineer's flash message.

When selecting 'vehicle' as the transaction type, the form was silently failing to submit because hidden 'real estate' fields, still marked as `required`, were triggering client-side HTML5 validation. Disabling inputs in hidden sections resolves this. Additionally, the engineer's success message for 'vehicle' transactions was checking for 'سيارة' instead of 'vehicle', which has been corrected.

---
<a href="https://cursor.com/background-agent?bcId=bc-9329b0ca-a8e0-4417-83ab-9ba0d50a4dee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9329b0ca-a8e0-4417-83ab-9ba0d50a4dee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

