### PR TITLE
Allow engineers to receive pending composite transactions

### DIFF
--- a/erp-valuation/templates/engineer.html
+++ b/erp-valuation/templates/engineer.html
@@ -72,7 +72,7 @@
                   <a href="{{ url_for('engineer_transaction_details', tid=t.id) }}" class="btn btn-info btn-sm">👁️ عرض التفاصيل</a>
                 </td>
                 <td>
-                  {% if not t.assigned_to and (t.status == "بانتظار المهندس" or t.status == "بانتظار تقرير المهندس") %}
+                  {% if t.status == "بانتظار المهندس" or t.status == "بانتظار تقرير المهندس" %}
                     <a href="{{ url_for('engineer_take', tid=t.id) }}" class="btn btn-sm btn-primary">استلام</a>
                   {% elif t.assigned_to == engineer.id and t.status == "قيد المعاينة" %}
                     <form method="POST" action="{{ url_for('engineer_upload_report', tid=t.id) }}" enctype="multipart/form-data" class="d-flex align-items-center gap-2">

--- a/erp-valuation/templates/engineer_transaction_details.html
+++ b/erp-valuation/templates/engineer_transaction_details.html
@@ -123,6 +123,12 @@
     </div>
   </div>
 
+  {% if session.get('role') == 'engineer' and (t.status == 'بانتظار المهندس' or t.status == 'بانتظار تقرير المهندس') %}
+  <div class="mb-3">
+    <a href="{{ url_for('engineer_take', tid=t.id) }}" class="btn btn-primary">استلام المعاملة</a>
+  </div>
+  {% endif %}
+
   <!-- ✅ رفع تقرير -->
   <div class="card mb-3">
     <div class="card-header bg-info text-white">📑 رفع تقرير</div>


### PR DESCRIPTION
Enable engineers to receive transactions in 'waiting for engineer' status to avoid redundant reporting.

Previously, engineers could not receive transactions if they were already assigned, even if the status was 'waiting for engineer'. This caused a workflow issue where reports had to be duplicated. This change ensures the 'receive' action is available on both the dashboard and transaction details page when the transaction is awaiting the engineer.

---
<a href="https://cursor.com/background-agent?bcId=bc-89488a6e-5f9d-4085-8bf3-7b12ee236c2c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-89488a6e-5f9d-4085-8bf3-7b12ee236c2c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

