### PR TITLE
Do not assign vehicle transaction until received

### DIFF
--- a/erp-valuation/app.py
+++ b/erp-valuation/app.py
@@ -762,15 +762,7 @@ def add_transaction():
 )
 
 
-        # 👨‍🔧 تعيين مباشر للمهندس (مثال: أول مهندس مسجل)
-        engineer = User.query.filter_by(role="engineer").first()
-        if engineer:
-            t.assigned_to = engineer.id
-
-        # 👨‍🔧 تعيين مباشر للمهندس (أول مهندس في نفس الفرع إن وجد)
-        engineer = User.query.filter_by(role="engineer", branch_id=user.branch_id).first()
-        if engineer:
-            t.assigned_to = engineer.id
+        # إبقاء معاملة المركبة غير مسندة حتى يقوم مهندس بالاستلام من لوحة المهندس
 
     # رفع الملفات
     files = request.files.getlist("files")


### PR DESCRIPTION
Remove automatic assignment of vehicle transactions to ensure they remain unassigned until an engineer explicitly receives them.

---
<a href="https://cursor.com/background-agent?bcId=bc-47ab6c2b-2046-46f0-848b-f030fe603b06">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-47ab6c2b-2046-46f0-848b-f030fe603b06">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

