### PR TITLE
Stamp and upload report with barcode

### DIFF
--- a/erp-valuation/templates/engineer.html
+++ b/erp-valuation/templates/engineer.html
@@ -78,6 +78,9 @@
                     <form method="POST" action="{{ url_for('engineer_upload_report', tid=t.id) }}" enctype="multipart/form-data" class="d-flex align-items-center gap-2">
                       <input type="file" name="report_file" class="form-control form-control-sm" accept=".pdf" required>
                       <button type="submit" class="btn btn-sm btn-success">📤 رفع</button>
+                      {% if t.report_sha256 %}
+                        <a class="btn btn-sm btn-outline-primary" href="{{ url_for('barcode_page') }}?hash={{ t.report_sha256 }}" target="_blank">QR</a>
+                      {% endif %}
                     </form>
                   {% endif %}
                 </td>

--- a/erp-valuation/templates/engineer_transaction_details.html
+++ b/erp-valuation/templates/engineer_transaction_details.html
@@ -139,6 +139,9 @@
     <input type="file" class="form-control" name="report_file" accept=".pdf" required>
   </div>
   <button type="submit" class="btn btn-success">⬆️ رفع التقرير</button>
+  {% if t.report_sha256 %}
+    <a class="btn btn-outline-primary ms-2" href="{{ url_for('barcode_page') }}?hash={{ t.report_sha256 }}" target="_blank">🧾 عرض QR والتحقق</a>
+  {% endif %}
 </form>
 
       <hr>


### PR DESCRIPTION
Add server-side QR code and text stamping to uploaded PDF reports.

This change automatically seals engineer-uploaded reports with a verifiable QR code and a text seal upon upload, consistent with the existing `index.html` functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-a36c8a27-2b17-4136-807b-eed397151f58">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a36c8a27-2b17-4136-807b-eed397151f58">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

