### PR TITLE
Handle none type attribute error

### DIFF
--- a/erp-valuation/app.py
+++ b/erp-valuation/app.py
@@ -1315,7 +1315,7 @@ def engineer_valuate_transaction(tid):
             Transaction.report_number != None
         ).order_by(Transaction.id.desc()).first()
 
-        if last_txn and last_txn.report_number.startswith("ref"):
+        if last_txn and isinstance(last_txn.report_number, str) and last_txn.report_number.startswith("ref"):
             last_num = int(last_txn.report_number.replace("ref", ""))
             t.report_number = f"ref{last_num + 1}"
         else:
@@ -1811,7 +1811,7 @@ def engineer_upload_report(tid):
             Transaction.report_number != None
         ).order_by(Transaction.id.desc()).first()
 
-        if last_txn and last_txn.report_number.startswith("ref"):
+        if last_txn and isinstance(last_txn.report_number, str) and last_txn.report_number.startswith("ref"):
             last_num = int(last_txn.report_number.replace("ref", ""))
             t.report_number = f"ref{last_num + 1}"
         else:


### PR DESCRIPTION
Add `isinstance` check to `report_number` before calling `startswith` to prevent `AttributeError` when `report_number` is `None`.

---
<a href="https://cursor.com/background-agent?bcId=bc-1a73927c-cfd5-4ca8-ac3c-e48344f272ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1a73927c-cfd5-4ca8-ac3c-e48344f272ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

