### PR TITLE
Fix psycopg2 import error

### DIFF
--- a/erp-valuation/app.py
+++ b/erp-valuation/app.py
@@ -54,8 +54,14 @@ default_sqlite_uri = f"sqlite:///{default_sqlite_path}"
 # دعم ربط PostgreSQL عبر متغير البيئة DATABASE_URL بما يتوافق مع SQLAlchemy
 database_url = os.environ.get("DATABASE_URL", default_sqlite_uri)
 if database_url.startswith("postgres://"):
-    # تحويل الصيغة القديمة إلى psycopg/psycopg2
-    database_url = database_url.replace("postgres://", "postgresql+psycopg2://", 1)
+    # تحويل الصيغة القديمة إلى محرك SQLAlchemy psycopg (psycopg v3)
+    database_url = database_url.replace("postgres://", "postgresql+psycopg://", 1)
+elif database_url.startswith("postgresql://"):
+    # فرض استخدام برنامج تشغيل psycopg v3 حتى لو كانت الصيغة حديثة بدون تحديد درايفر
+    database_url = database_url.replace("postgresql://", "postgresql+psycopg://", 1)
+elif database_url.startswith("postgresql+psycopg2://"):
+    # ترقية أي توجيه قديم إلى psycopg v3
+    database_url = database_url.replace("postgresql+psycopg2://", "postgresql+psycopg://", 1)
 
 # فرض SSL على Render وما شابه إذا لم يُذكر صراحةً
 if database_url.startswith("postgresql") and "sslmode=" not in database_url:

--- a/erp-valuation/requirements.txt
+++ b/erp-valuation/requirements.txt
@@ -26,7 +26,7 @@ multidict==6.6.4
 packaging==25.0
 pillow==11.3.0
 propcache==0.3.2
-psycopg2-binary==2.9.8
+psycopg[binary]==3.2.3
 py-vapid==1.9.2
 pycparser==2.22
 PyMuPDF==1.26.3


### PR DESCRIPTION
Upgrade from `psycopg2` to `psycopg` v3 to resolve `_PyInterpreterState_Get` import error on Python 3.13.

The `psycopg2` library has known compatibility issues with Python 3.13, causing an `ImportError` due to an undefined symbol `_PyInterpreterState_Get`. This PR updates the database driver to `psycopg` (version 3), which is fully compatible with Python 3.13, and adjusts the SQLAlchemy connection strings to use the new driver.

---
<a href="https://cursor.com/background-agent?bcId=bc-4141f01d-b23f-4650-a39b-5b9f1c7968b9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4141f01d-b23f-4650-a39b-5b9f1c7968b9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

