### PR TITLE
Fix strftime usage in postgresql query

### DIFF
--- a/erp-valuation/app.py
+++ b/erp-valuation/app.py
@@ -1127,6 +1127,12 @@ def manager_dashboard():
 
     now = datetime.utcnow()
     hidden_statuses =     "in_progress"   ,  "بإنتظار المهندس" , "قيد المعاينة", "📑 تقرير مرفوع" ,  "بانتظار المهندس",
+    # Current month boundaries (UTC) for Postgres-compatible filtering
+    month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    if now.month == 12:
+        next_month_start = datetime(now.year + 1, 1, 1)
+    else:
+        next_month_start = datetime(now.year, now.month + 1, 1)
     VAPID_PUBLIC_KEY = "BFNeZpjEro8pwFxR1H20twlTd2pL5MZtWrDATu4ME2RcbzhN"  # المفتاح اللي ولدته
 
     # ✅ فقط معاملات العقارات تظهر عند المدير + استبعاد الحالات المخفية
@@ -1156,8 +1162,8 @@ def manager_dashboard():
             .join(Transaction, Transaction.bank_id == Bank.id)
             .filter(Transaction.branch_id == b.id)
             .filter(Transaction.transaction_type == "real_estate")   # 🚫 استبعاد السيارات
-            .filter(func.strftime("%m", Transaction.date) == now.strftime("%m"))
-            .filter(func.strftime("%Y", Transaction.date) == now.strftime("%Y"))
+            .filter(Transaction.date >= month_start)
+            .filter(Transaction.date < next_month_start)
             .group_by(Bank.name)
             .all()
         )


### PR DESCRIPTION
Replace SQLite's `func.strftime` with PostgreSQL-compatible date range filtering to fix the `/manager` endpoint error.

The `strftime` function used in the original SQLAlchemy query is a SQLite-specific function. When the application was deployed with a PostgreSQL database, this function was not found, leading to a `psycopg.errors.UndefinedFunction` error and a 500 response on the `/manager` dashboard. The fix involves changing the filtering logic to use standard date comparison operators (`>=` and `<`) with calculated month boundaries, which is compatible with PostgreSQL.

---
<a href="https://cursor.com/background-agent?bcId=bc-f9a95289-aefa-4cf4-9bd2-3483ace50dec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f9a95289-aefa-4cf4-9bd2-3483ace50dec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

