### PR TITLE
Disable automatic page updates

### DIFF
--- a/erp-valuation/templates/employee.html
+++ b/erp-valuation/templates/employee.html
@@ -526,35 +526,6 @@
     }
   }
   </script>
-  <script>
-  // 🔄 تحديث لحظي: فحص نسخة المعاملات
-  (function autoReloadOnChanges(){
-    var currentVersion = null;
-    var lastPingFail = 0;
-    async function checkVersion(){
-      try {
-        const res = await fetch('/api/transactions/version', { cache: 'no-store' });
-        if (!res.ok) throw new Error('bad status');
-        const data = await res.json();
-        if (currentVersion === null) {
-          currentVersion = data.version;
-        } else if (data.version !== currentVersion) {
-          // إذا كان المستخدم لا يحرر، اسمح بالتحديث المباشر، وإلا أظهر لافتة
-          if (!__isUserEditing) {
-            location.reload();
-          } else {
-            var b = __ensureUpdateBanner();
-            b.style.display = 'block';
-          }
-        }
-      } catch (e) {
-        lastPingFail++;
-        if (lastPingFail > 5) lastPingFail = 0;
-      }
-    }
-    setInterval(checkVersion, 3000);
-    setTimeout(checkVersion, 1000);
-  })();
-  </script>
+  <!-- تم تعطيل التحديث التلقائي -->
 {% endblock %}
 

--- a/erp-valuation/templates/engineer.html
+++ b/erp-valuation/templates/engineer.html
@@ -197,33 +197,5 @@ function __ensureUpdateBanner(){
 }
 document.addEventListener('DOMContentLoaded', __setupEditingGuards);
 </script>
-<script>
-// 🔄 تحديث لحظي بسيط: فحص نسخة المعاملات وإعادة تحميل الصفحة عند تغيّرها
-(function autoReloadOnChanges(){
-  var currentVersion = null;
-  var lastPingFail = 0;
-  async function checkVersion(){
-    try {
-      const res = await fetch('/api/transactions/version', { cache: 'no-store' });
-      if (!res.ok) throw new Error('bad status');
-      const data = await res.json();
-      if (currentVersion === null) {
-        currentVersion = data.version;
-      } else if (data.version !== currentVersion) {
-        if (!__isUserEditing) {
-          location.reload();
-        } else {
-          var b = __ensureUpdateBanner();
-          b.style.display = 'block';
-        }
-      }
-    } catch (e) {
-      lastPingFail++;
-      if (lastPingFail > 5) lastPingFail = 0;
-    }
-  }
-  setInterval(checkVersion, 3000);
-  setTimeout(checkVersion, 1000);
-})();
-</script>
+<!-- تم تعطيل التحديث التلقائي -->
 {% endblock %}

--- a/erp-valuation/templates/finance.html
+++ b/erp-valuation/templates/finance.html
@@ -454,35 +454,7 @@ function __ensureUpdateBanner(){
 }
 document.addEventListener('DOMContentLoaded', __setupEditingGuards);
 </script>
-<script>
-// 🔄 تحديث لحظي بسيط: فحص نسخة المعاملات وإعادة تحميل الصفحة عند تغيّرها
-(function autoReloadOnChanges(){
-  var currentVersion = null;
-  var lastPingFail = 0;
-  async function checkVersion(){
-    try {
-      const res = await fetch('/api/transactions/version', { cache: 'no-store' });
-      if (!res.ok) throw new Error('bad status');
-      const data = await res.json();
-      if (currentVersion === null) {
-        currentVersion = data.version;
-      } else if (data.version !== currentVersion) {
-        if (!__isUserEditing) {
-          location.reload();
-        } else {
-          var b = __ensureUpdateBanner();
-          b.style.display = 'block';
-        }
-      }
-    } catch (e) {
-      lastPingFail++;
-      if (lastPingFail > 5) lastPingFail = 0;
-    }
-  }
-  setInterval(checkVersion, 3000);
-  setTimeout(checkVersion, 1000);
-})();
-</script>
+<!-- تم تعطيل التحديث التلقائي -->
 <script>
 if ("serviceWorker" in navigator && "PushManager" in window) {
   navigator.serviceWorker.register("/service-worker.js")

--- a/erp-valuation/templates/manager_dashboard.html
+++ b/erp-valuation/templates/manager_dashboard.html
@@ -257,37 +257,7 @@ function __ensureUpdateBanner(){
 }
 document.addEventListener('DOMContentLoaded', __setupEditingGuards);
 </script>
-<script>
-// 🔄 تحديث لحظي بسيط: فحص نسخة المعاملات وإعادة تحميل الصفحة عند تغيّرها
-(function autoReloadOnChanges(){
-  var currentVersion = null;
-  var lastPingFail = 0;
-  async function checkVersion(){
-    try {
-      const res = await fetch('/api/transactions/version', { cache: 'no-store' });
-      if (!res.ok) throw new Error('bad status');
-      const data = await res.json();
-      if (currentVersion === null) {
-        currentVersion = data.version;
-      } else if (data.version !== currentVersion) {
-        if (!__isUserEditing) {
-          location.reload();
-        } else {
-          var b = __ensureUpdateBanner();
-          b.style.display = 'block';
-        }
-      }
-    } catch (e) {
-      // تهدئة الفشل
-      lastPingFail++;
-      if (lastPingFail > 5) lastPingFail = 0;
-    }
-  }
-  setInterval(checkVersion, 3000);
-  // أول فحص سريع
-  setTimeout(checkVersion, 1000);
-})();
-</script>
+<!-- تم تعطيل التحديث التلقائي -->
 {% endblock %}
 
 


### PR DESCRIPTION
Remove auto-reload polling scripts to disable automatic page refreshes across dashboards.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f89e43b-4418-4390-bd6f-37a75aedcc90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8f89e43b-4418-4390-bd6f-37a75aedcc90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

