### PR TITLE
Fix flask before_first_request attribute error

### DIFF
--- a/erp-valuation/app.py
+++ b/erp-valuation/app.py
@@ -4279,23 +4279,29 @@ with app.app_context():
     except Exception:
         db.session.rollback()
 
-# ضمان وجود أعمدة Backblaze B2 قبل أول طلب (في بيئات الإنتاج متعددة العمليات)
-@app.before_first_request
+# ضمان وجود أعمدة Backblaze B2 عند بدء التشغيل (متوافق مع Flask 3.x)
 def ensure_b2_columns_exist():
     try:
         if not column_exists("transaction", "report_b2_file_name"):
             db.session.execute(text('ALTER TABLE "transaction" ADD COLUMN report_b2_file_name VARCHAR(255)'))
             db.session.commit()
-            print("✅ تمت إضافة عمود report_b2_file_name (before_first_request)")
+            print("✅ تمت إضافة عمود report_b2_file_name")
     except Exception:
         db.session.rollback()
     try:
         if not column_exists("transaction", "report_b2_file_id"):
             db.session.execute(text('ALTER TABLE "transaction" ADD COLUMN report_b2_file_id VARCHAR(255)'))
             db.session.commit()
-            print("✅ تمت إضافة عمود report_b2_file_id (before_first_request)")
+            print("✅ تمت إضافة عمود report_b2_file_id")
     except Exception:
         db.session.rollback()
+
+# تشغيل مهمة التهيئة عند بدء التشغيل لضمان الأعمدة المطلوبة
+try:
+    with app.app_context():
+        ensure_b2_columns_exist()
+except Exception as e:
+    print(f"⚠️ فشل ضمان أعمدة B2 عند بدء التشغيل: {e}")
 
 # ---------------- تقرير دخل موظف ----------------
 @app.route("/employee_income", methods=["GET", "POST"])


### PR DESCRIPTION
Replace deprecated `app.before_first_request` with an immediate call within `app.app_context()` to ensure Flask 3.x compatibility and fix deployment.

The `before_first_request` decorator was removed in Flask 3.x, leading to an `AttributeError` during application startup. This change updates the column existence check to run at import time within an application context, resolving the deployment crash.

---
<a href="https://cursor.com/background-agent?bcId=bc-3596c204-b93f-4caa-b242-d8ab3192ba1d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3596c204-b93f-4caa-b242-d8ab3192ba1d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

