### PR TITLE
Update employee commission filter for all transaction holders

### DIFF
--- a/erp-valuation/templates/commission.html
+++ b/erp-valuation/templates/commission.html
@@ -43,11 +43,11 @@
   <form method="POST" class="mb-4">
     <div class="row g-2">
       <div class="col-12 col-md-6">
-        <select class="form-select" name="user_id" required>
-          <option value="">-- اختر موظف --</option>
-          {% for u in users %}
-            <option value="{{ u.id }}" {% if selected_user_id and u.id == selected_user_id|int %}selected{% endif %}>
-              {{ u.username }}
+        <select class="form-select" name="brought_by" required>
+          <option value="">-- اختر اسم من جلب المعاملة --</option>
+          {% for name in brought_by_names %}
+            <option value="{{ name }}" {% if selected_brought_by and name == selected_brought_by %}selected{% endif %}>
+              {{ name }}
             </option>
           {% endfor %}
         </select>


### PR DESCRIPTION
Update the employee commission filter to include all names from transaction records, not just registered users.

The previous filter for employee commissions only allowed selecting from a list of registered employees. This change expands the filter options to include any name recorded in the `brought_by` field of transactions, ensuring that commissions can be tracked for all individuals who generated business, even if they are not formal users in the system.

---
<a href="https://cursor.com/background-agent?bcId=bc-255cb986-cb0e-488a-9788-599927599ceb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-255cb986-cb0e-488a-9788-599927599ceb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

