### PR TITLE
Fix duplicated tax field on bank invoices

### DIFF
--- a/erp-valuation/templates/finance.html
+++ b/erp-valuation/templates/finance.html
@@ -80,17 +80,6 @@
                   <label class="form-label">نسبة الضريبة %</label>
                   <input type="number" step="0.01" min="0" max="100" name="vat" class="form-control" value="{{ vat_default_percent }}">
                 </div>
-                <div class="col-6">
-                  <label class="form-label">تطبيق الضريبة</label>
-                  <select name="apply_vat" class="form-select">
-                    <option value="1" selected>نعم</option>
-                    <option value="0">لا</option>
-                  </select>
-                </div>
-                <div class="col-6">
-                  <label class="form-label">نسبة الضريبة %</label>
-                  <input type="number" step="0.01" min="0" max="100" name="vat" class="form-control" value="{{ vat_default_percent }}">
-                </div>
                 <div class="col-12 d-flex justify-content-end">
                   <button class="btn btn-success">إصدار فاتورة</button>
                 </div>
@@ -110,7 +99,6 @@
                   <thead class="table-dark">
                     <tr>
                       <th>#</th>
-                      <th>رقم الفاتورة</th>
                       <th>رقم الفاتورة</th>
                       <th>البنك</th>
                       <th>المبلغ</th>


### PR DESCRIPTION
Remove duplicate tax fields from the bank invoice form and a duplicate table header in the bank invoices list.

---
<a href="https://cursor.com/background-agent?bcId=bc-42d164e1-a2b6-4b25-b61a-79b1f5dc03c4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-42d164e1-a2b6-4b25-b61a-79b1f5dc03c4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

