### PR TITLE
Upload bank documents to backblaze

### DIFF
--- a/erp-valuation/templates/bank_detail.html
+++ b/erp-valuation/templates/bank_detail.html
@@ -167,7 +167,10 @@
                   <td>{{ d.id }}</td>
                   <td>{{ d.title }}</td>
                   <td>
-                    {% if d.file %}
+                    {% set b2url = build_b2_public_url(d.b2_file_name) if d.b2_file_name else None %}
+                    {% if b2url %}
+                      <a class="btn btn-sm btn-outline-primary" href="{{ b2url }}" target="_blank">فتح</a>
+                    {% elif d.file %}
                       <a class="btn btn-sm btn-outline-primary" href="{{ url_for('uploaded_file', filename=d.file) }}" target="_blank">فتح</a>
                     {% else %} - {% endif %}
                   </td>

--- a/erp-valuation/templates/branch_documents.html
+++ b/erp-valuation/templates/branch_documents.html
@@ -72,7 +72,10 @@
                 {% else %}<span class="badge bg-success">ساري</span>{% endif %}
               </td>
               <td>
-                {% if d.file %}
+                {% set b2url = build_b2_public_url(d.b2_file_name) if d.b2_file_name else None %}
+                {% if b2url %}
+                <a href="{{ b2url }}" class="btn btn-sm btn-outline-primary" target="_blank">فتح</a>
+                {% elif d.file %}
                 <a href="{{ url_for('uploaded_file', filename=d.file) }}" class="btn btn-sm btn-outline-primary" target="_blank">فتح</a>
                 {% else %}-{% endif %}
               </td>

--- a/erp-valuation/templates/employee.html
+++ b/erp-valuation/templates/employee.html
@@ -298,7 +298,10 @@
                         <span class="badge {% if s=='ساري' %}bg-success{% elif s=='قريب الانتهاء' %}bg-warning text-dark{% elif s=='منتهي' %}bg-danger{% else %}bg-secondary{% endif %}">{{ s }}</span>
                       </td>
                       <td>
-                        {% if d.file %}
+                        {% set b2url = build_b2_public_url(d.b2_file_name) if d.b2_file_name else None %}
+                        {% if b2url %}
+                          <a href="{{ b2url }}" target="_blank">فتح</a>
+                        {% elif d.file %}
                           <a href="{{ url_for('uploaded_file', filename=d.file) }}" target="_blank">فتح</a>
                         {% else %}
                           —


### PR DESCRIPTION
Integrate Backblaze B2 for branch and bank document uploads, storing files on B2 and replacing the 'Open' button with direct B2 public links, with a fallback to local storage.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f3147d9-e257-42f7-b409-1525092711fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9f3147d9-e257-42f7-b409-1525092711fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

