### PR TITLE
Fix undefined jinja function build_b2_public_url

### DIFF
--- a/erp-valuation/app.py
+++ b/erp-valuation/app.py
@@ -110,6 +110,13 @@ def build_b2_public_url(file_name: str) -> str | None:
     except Exception:
         return None
 
+# اجعل الدالة متاحة داخل قوالب Jinja مباشرةً
+@app.context_processor
+def inject_template_helpers():
+    return {
+        "build_b2_public_url": build_b2_public_url,
+    }
+
 # ---------------- إعداد مفاتيح Web Push (VAPID) ----------------
 # يمكن ضبطها عبر متغيرات البيئة VAPID_PUBLIC_KEY / VAPID_PRIVATE_KEY / VAPID_SUBJECT
 app.config["VAPID_PUBLIC_KEY"] = os.environ.get(


### PR DESCRIPTION
Register `build_b2_public_url` as a Jinja context processor to resolve `UndefinedError` in templates.

---
<a href="https://cursor.com/background-agent?bcId=bc-4be58f0d-ba08-4ea1-84b7-4f136f56c6a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4be58f0d-ba08-4ea1-84b7-4f136f56c6a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

