### PR TITLE
Display documents instead of downloading

### DIFF
--- a/erp-valuation/templates/bank_detail.html
+++ b/erp-valuation/templates/bank_detail.html
@@ -188,12 +188,18 @@
                   <td>
                     {% set b2url = build_b2_public_url(d.b2_file_name) if d.b2_file_name else None %}
                     <div class="btn-group btn-group-sm" role="group">
-                      {% if b2url %}
-                        <a class="btn btn-outline-primary" href="{{ b2url }}" target="_blank">عرض</a>
-                        <a class="btn btn-outline-secondary" href="{{ url_for('download_b2_file') }}?file={{ d.b2_file_name }}">تنزيل</a>
-                      {% elif d.file %}
-                        <a class="btn btn-outline-primary" href="{{ url_for('uploaded_file', filename=d.file) }}" target="_blank">عرض</a>
-                        <a class="btn btn-outline-secondary" href="{{ url_for('download_local_file', filename=d.file) }}">تنزيل</a>
+                      {% if b2url or d.file %}
+                        {% set src = b2url if b2url else url_for('uploaded_file', filename=d.file, _external=True) %}
+                        {% set name = d.b2_file_name if b2url else d.file %}
+                        {% set ext = (name.rsplit('.', 1)[1] | lower) if (name and '.' in name) else '' %}
+                        {% set office_exts = ['doc','docx','xls','xlsx','ppt','pptx'] %}
+                        {% set view_href = ('https://view.officeapps.live.com/op/view.aspx?src=' ~ (src | urlencode)) if ext in office_exts else src %}
+                        <a class="btn btn-outline-primary" href="{{ view_href }}" target="_blank">عرض</a>
+                        {% if b2url %}
+                          <a class="btn btn-outline-secondary" href="{{ url_for('download_b2_file') }}?file={{ d.b2_file_name }}">تنزيل</a>
+                        {% else %}
+                          <a class="btn btn-outline-secondary" href="{{ url_for('download_local_file', filename=d.file) }}">تنزيل</a>
+                        {% endif %}
                       {% else %}
                         -
                       {% endif %}

--- a/erp-valuation/templates/branch_documents.html
+++ b/erp-valuation/templates/branch_documents.html
@@ -74,12 +74,18 @@
               <td>
                 <div class="btn-group btn-group-sm" role="group">
                   {% set b2url = build_b2_public_url(d.b2_file_name) if d.b2_file_name else None %}
-                  {% if b2url %}
-                    <a href="{{ b2url }}" class="btn btn-outline-primary" target="_blank">عرض</a>
-                    <a href="{{ url_for('download_b2_file') }}?file={{ d.b2_file_name }}" class="btn btn-outline-secondary">تنزيل</a>
-                  {% elif d.file %}
-                    <a href="{{ url_for('uploaded_file', filename=d.file) }}" class="btn btn-outline-primary" target="_blank">عرض</a>
-                    <a href="{{ url_for('download_local_file', filename=d.file) }}" class="btn btn-outline-secondary">تنزيل</a>
+                  {% if b2url or d.file %}
+                    {% set src = b2url if b2url else url_for('uploaded_file', filename=d.file, _external=True) %}
+                    {% set name = d.b2_file_name if b2url else d.file %}
+                    {% set ext = (name.rsplit('.', 1)[1] | lower) if (name and '.' in name) else '' %}
+                    {% set office_exts = ['doc','docx','xls','xlsx','ppt','pptx'] %}
+                    {% set view_href = ('https://view.officeapps.live.com/op/view.aspx?src=' ~ (src | urlencode)) if ext in office_exts else src %}
+                    <a href="{{ view_href }}" class="btn btn-outline-primary" target="_blank">عرض</a>
+                    {% if b2url %}
+                      <a href="{{ url_for('download_b2_file') }}?file={{ d.b2_file_name }}" class="btn btn-outline-secondary">تنزيل</a>
+                    {% else %}
+                      <a href="{{ url_for('download_local_file', filename=d.file) }}" class="btn btn-outline-secondary">تنزيل</a>
+                    {% endif %}
                   {% else %}
                     -
                   {% endif %}


### PR DESCRIPTION
Modify 'عرض' buttons to display bank and branch documents inline, utilizing Office Web Viewer for Office files, to prevent automatic downloads.

---
<a href="https://cursor.com/background-agent?bcId=bc-7b102dcf-25e5-424b-a6c0-ff5a25e5bbea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7b102dcf-25e5-424b-a6c0-ff5a25e5bbea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

