### PR TITLE
Fix document view link

### DIFF
--- a/erp-valuation/app.py
+++ b/erp-valuation/app.py
@@ -3789,7 +3789,20 @@ def public_report(token):
 # ---------------- عرض الملفات ----------------
 @app.route("/uploads/<path:filename>")
 def uploaded_file(filename):
-    return send_from_directory(app.config["UPLOAD_FOLDER"], filename)
+    resp = send_from_directory(app.config["UPLOAD_FOLDER"], filename)
+    try:
+        # Ensure inline display in browser tabs instead of forced download
+        basename = os.path.basename(filename)
+        resp.headers["Content-Disposition"] = f'inline; filename="{basename}"'
+        # Make sure Content-Type is set appropriately for better inline rendering
+        if not resp.headers.get("Content-Type") or resp.headers.get("Content-Type") == "application/octet-stream":
+            import mimetypes
+            guessed, _ = mimetypes.guess_type(basename)
+            if guessed:
+                resp.headers["Content-Type"] = guessed
+    except Exception:
+        pass
+    return resp
 
 # تنزيل ملف محلي من مجلد الرفع مع إجبار التنزيل
 @app.route("/download/local/<path:filename>")

--- a/erp-valuation/templates/employee.html
+++ b/erp-valuation/templates/employee.html
@@ -302,7 +302,13 @@
                         {% if b2url %}
                           <a href="{{ b2url }}" target="_blank">فتح</a>
                         {% elif d.file %}
-                          <a href="{{ url_for('uploaded_file', filename=d.file) }}" target="_blank">فتح</a>
+                          {# Force inline view for Office docs via Office Viewer; otherwise direct #}
+                          {% set name = d.file %}
+                          {% set ext = (name.rsplit('.', 1)[1] | lower) if (name and '.' in name) else '' %}
+                          {% set office_exts = ['doc','docx','xls','xlsx','ppt','pptx'] %}
+                          {% set src = url_for('uploaded_file', filename=d.file, _external=True) %}
+                          {% set view_href = ('https://view.officeapps.live.com/op/view.aspx?src=' ~ (src | urlencode)) if ext in office_exts else src %}
+                          <a href="{{ view_href }}" target="_blank">فتح</a>
                         {% else %}
                           —
                         {% endif %}

--- a/erp-valuation/templates/engineer_transaction_details.html
+++ b/erp-valuation/templates/engineer_transaction_details.html
@@ -116,7 +116,12 @@
       {% if t.files %}
         <ul>
           {% for f in t.files.split(",") %}
-            <li><a href="{{ url_for('uploaded_file', filename=f) }}" target="_blank">{{ f }}</a></li>
+            {% set name = f %}
+            {% set ext = (name.rsplit('.', 1)[1] | lower) if (name and '.' in name) else '' %}
+            {% set office_exts = ['doc','docx','xls','xlsx','ppt','pptx'] %}
+            {% set src = url_for('uploaded_file', filename=f, _external=True) %}
+            {% set view_href = ('https://view.officeapps.live.com/op/view.aspx?src=' ~ (src | urlencode)) if ext in office_exts else src %}
+            <li><a href="{{ view_href }}" target="_blank">{{ f }}</a></li>
           {% endfor %}
         </ul>
       {% else %}

--- a/erp-valuation/templates/finance_paid.html
+++ b/erp-valuation/templates/finance_paid.html
@@ -61,7 +61,12 @@
               <td>{{ p.date_received.strftime('%Y-%m-%d') if p.date_received else '-' }}</td>
               <td>
                 {% if p.receipt_file %}
-                  <a href="{{ url_for('uploaded_file', filename=p.receipt_file) }}" target="_blank">📎 عرض</a>
+                  {% set name = p.receipt_file %}
+                  {% set ext = (name.rsplit('.', 1)[1] | lower) if (name and '.' in name) else '' %}
+                  {% set office_exts = ['doc','docx','xls','xlsx','ppt','pptx'] %}
+                  {% set src = url_for('uploaded_file', filename=p.receipt_file, _external=True) %}
+                  {% set view_href = ('https://view.officeapps.live.com/op/view.aspx?src=' ~ (src | urlencode)) if ext in office_exts else src %}
+                  <a href="{{ view_href }}" target="_blank">📎 عرض</a>
                 {% else %}
                   -
                 {% endif %}

--- a/erp-valuation/templates/manager_dashboard.html
+++ b/erp-valuation/templates/manager_dashboard.html
@@ -147,7 +147,12 @@
                 {% for fname in (t.bank_sent_files or '').split(',') %}
                   {% set f = (fname or '').strip() %}
                   {% if f %}
-                  <li><a href="{{ url_for('uploaded_file', filename=f) }}" target="_blank">{{ f }}</a></li>
+                  {% set name = (f or '').strip() %}
+                  {% set ext = (name.rsplit('.', 1)[1] | lower) if (name and '.' in name) else '' %}
+                  {% set office_exts = ['doc','docx','xls','xlsx','ppt','pptx'] %}
+                  {% set src = url_for('uploaded_file', filename=f, _external=True) %}
+                  {% set view_href = ('https://view.officeapps.live.com/op/view.aspx?src=' ~ (src | urlencode)) if ext in office_exts else src %}
+                  <li><a href="{{ view_href }}" target="_blank">{{ f }}</a></li>
                   {% endif %}
                 {% endfor %}
               </ul>

--- a/erp-valuation/templates/result.html
+++ b/erp-valuation/templates/result.html
@@ -26,7 +26,12 @@
     </div>
 
     {% if filename %}
-      <a class="btn btn-outline-secondary mt-3" href="/uploads/{{ filename }}" target="_blank">📂 عرض المستند المرفوع</a>
+      {% set name = filename %}
+      {% set ext = (name.rsplit('.', 1)[1] | lower) if (name and '.' in name) else '' %}
+      {% set office_exts = ['doc','docx','xls','xlsx','ppt','pptx'] %}
+      {% set src = url_for('uploaded_file', filename=filename, _external=True) %}
+      {% set view_href = ('https://view.officeapps.live.com/op/view.aspx?src=' ~ (src | urlencode)) if ext in office_exts else src %}
+      <a class="btn btn-outline-secondary mt-3" href="{{ view_href }}" target="_blank">📂 عرض المستند المرفوع</a>
     {% endif %}
 
     <div class="mt-3">


### PR DESCRIPTION
Change 'View' links to open documents inline in the browser instead of forcing a download.

---
<a href="https://cursor.com/background-agent?bcId=bc-21a83856-78e6-4583-9afc-2db355da453b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-21a83856-78e6-4583-9afc-2db355da453b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

